### PR TITLE
Replace deprecated dash-functional dependency

### DIFF
--- a/celery.el
+++ b/celery.el
@@ -4,7 +4,7 @@
 
 ;; Author: ardumont <eniotna.t@gmail.com>
 ;; Keywords: celery, convenience
-;; Package-Requires: ((emacs "24") (dash-functional "2.11.0") (s "1.9.0") (deferred "0.3.2"))
+;; Package-Requires: ((emacs "24") (dash "2.18.0") (s "1.9.0") (deferred "0.3.2"))
 ;; Version: 0.0.3
 ;; URL: https://github.com/ardumont/emacs-celery
 
@@ -43,7 +43,7 @@
 ;;; Code:
 
 (require 'deferred)
-(require 'dash-functional)
+(require 'dash)
 (require 'json)
 (require 's)
 


### PR DESCRIPTION
Dash 2.18.0 now subsumes `dash-functional`.

See https://github.com/magnars/dash.el/blob/master/NEWS.md#from-217-to-218